### PR TITLE
DA-1686 Crash in photo library after recording video

### DIFF
--- a/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
+++ b/YangMingShan/YMSPhotoPicker/Public/YMSPhotoPickerViewController.m
@@ -796,7 +796,10 @@ static const CGFloat YMSPhotoFetchScaleResizingRatio = 0.75;
             fetchResult = [self.collectionItems firstObject][@"assets"];
             PHAsset *asset = [fetchResult firstObject];
             [self.selectedPhotos addObject:asset];
-            self.doneItem.enabled = YES;
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                self.doneItem.enabled = YES;
+            });
         }
 
         return;


### PR DESCRIPTION
https://1stdibs.atlassian.net/browse/DA-1686

Make sure `self.doneItem.enabled = YES;` is called on the main thread. This should fix the crash in the ticket.

Gondor PR: https://github.com/1stdibs/Gondor/pull/4006